### PR TITLE
Change request a queue button to be text with a link + other small changes

### DIFF
--- a/components/GenericLink.jsx
+++ b/components/GenericLink.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import NextLink from 'next/link'
 
 const GenericLink = props => {
-  if (!props.href.startsWith('http://') && !props.href.startsWith('http://')) {
+  if (!props.href.startsWith('http://') && !props.href.startsWith('https://')) {
     return <InternalLink {...props} />
   } else {
     return <OtherLink {...props} />

--- a/pages/blog/dark-mode-access-tokens.mdx
+++ b/pages/blog/dark-mode-access-tokens.mdx
@@ -4,7 +4,7 @@ import Image from '../../components/Image'
 export const meta = {
   title: 'Announcing Queue v1.2.0: Dark Mode & Access Tokens!',
   date: '2019-04-22T17:30:00-0500',
-  featured: true,
+  featured: false,
   authors: [
     {
       name: 'Jacqueline Osborn',

--- a/pages/index.js
+++ b/pages/index.js
@@ -44,14 +44,15 @@ export default () => {
               >
                 Go to the Queue
               </Button>
-              <Button
-                color="secondary"
-                className="m-2"
-                tag="a"
-                href="https://go.illinois.edu/new-queue/"
-              >
-                Request a queue
-              </Button>
+              <p className="text-light mt-2">
+                Are you a member of Course Staff?{' '}
+                <a
+                  style={{ color: '#4396ca' }}
+                  href="https://go.illinois.edu/new-queue/"
+                >
+                  Request a queue
+                </a>
+              </p>
             </div>
           </Col>
         </Row>


### PR DESCRIPTION
This PR:
* Fixes a logic error in `GenericLink` to include https
* "Unfeatures" the dark mode and access tokens blog post (due to it being a bit old now)
* Changes the "request a queue" button to be text saying: "Are you a member of course staff? Request a queue", with "request a queue" being linked to the form.  This was motivated by a large influx of students misinterpreting the "request a queue" to be a link to a course's queue.  See below:

![image](https://user-images.githubusercontent.com/32113753/64748421-b61e3180-d4d7-11e9-8831-259413391a64.png)
